### PR TITLE
Change title 'React App' into 'Resume builder' #1

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -24,7 +24,7 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
-    <title>React App</title>
+    <title>Resume Builder</title>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>


### PR DESCRIPTION
To change the title of the page I modified the **`/public/index.html`** file
The changes I made were :

1. In the header tag of the **index.html** I found the title tag
2. I deleted the default title text which was **React App**
3. I then changed it to **Resume Builder**

Hope this was the only required change
