### PR TITLE
The weird 'Full Stop' #3

### DIFF
--- a/src/components/Header/Header.jsx
+++ b/src/components/Header/Header.jsx
@@ -10,7 +10,7 @@ const Header = () => {
         </p>
 
         <p className={styles.heading}>
-            Make your own resume . <span> It's free</span>
+            Make your own resume.<span> It's free</span>
         </p>
         </div>
         

--- a/src/components/Header/Header.module.css
+++ b/src/components/Header/Header.module.css
@@ -16,7 +16,7 @@
     background-color: black;
     background-clip: text;
     color: transparent;
-    max-width: 552px;
+    max-width: 570px;
     font-size: 3rem;
     font-weight: bold;
     letter-spacing: 1px;


### PR DESCRIPTION
To make the 'Full Stop; I changed the max width of the CSS box to accommodate the full stop on the upper line

**Changes made**
1. Removed the spaces in the Header.jsx file to accommodate the full stop in the least possible space
2. Changed the max width of the CSS box to accommodate it better
3. The new max-width is 570px

The present site looks like this:
![image](https://user-images.githubusercontent.com/93852415/180033061-234ebeab-8d32-48c1-8429-3f8b4abf89c8.png)
